### PR TITLE
🐛 fix: use heredoc to write valid .flake8 config and restore CI lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,12 @@ jobs:
       run: |
         black ./projects ./tools --check --diff
 
-    - name: Lint with flake8
+   - name: Lint with flake8
       run: |
-        echo "[flake8]" > .flake8
-        echo "max-line-length =
+        cat <<EOF > .flake8
+        [flake8]
+        max-line-length = 88
+        exclude = .git,__pycache__,.venv
+        EOF
 
+        flake8 ./projects ./tools

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # ✅ critical for valid commit SHA range
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -23,3 +25,4 @@ jobs:
         run: |
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
           npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.event.pull_request.head.sha }} --verbose
+


### PR DESCRIPTION
### Summary
This PR resolves the broken CI linter step caused by improper shell quoting when generating `.flake8`.

### What's Changed
- Replaced `echo` with a `cat <<EOF` heredoc block for safe `.flake8` creation
- Configured `.flake8` with:
  ```ini
  [flake8]
  max-line-length = 88
  exclude = .git,__pycache__,.venv
